### PR TITLE
SQLite support and some clean-up

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,217 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.TagFIXME, []},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now)
+          {Credo.Check.Refactor.UtcNowTruncate, []},
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    }
+  ]
+}

--- a/.credo.exs
+++ b/.credo.exs
@@ -96,7 +96,7 @@
           #
           {Credo.Check.Readability.AliasOrder, []},
           {Credo.Check.Readability.FunctionNames, []},
-          {Credo.Check.Readability.LargeNumbers, []},
+          # {Credo.Check.Readability.LargeNumbers, []},
           {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
           {Credo.Check.Readability.ModuleAttributeNames, []},
           {Credo.Check.Readability.ModuleDoc, []},

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,priv}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ ex_double_entry-*.tar
 /tmp/
 
 mix.lock
+
+# SQLite files
+*.db*

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,10 @@ config :ex_double_entry, ExDoubleEntry.Repo,
   database: "ex_double_entry_dev",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+# When using SQLite
+# config :ex_double_entry, ExDoubleEntry.Repo,
+#   database: Path.expand("../ex_double_entry_dev.db", __DIR__),
+#   pool_size: 5,
+#   stacktrace: true,
+#   show_sensitive_data_on_connection_error: true

--- a/config/test_sqlite3.exs
+++ b/config/test_sqlite3.exs
@@ -1,0 +1,17 @@
+import Config
+
+config :ex_double_entry,
+  db: :sqlite3
+
+config :ex_double_entry, ExDoubleEntry.Repo,
+  database: System.get_env("SQLITE_DB_PATH", "ex_double_entry_test.db"),
+  adapter: Ecto.Adapters.SQLite3,
+  journal_mode: :wal,
+  pool_size: 1,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  show_sensitive_data_on_connection_error: true,
+  timeout: :infinity,
+  queue_target: 200,
+  queue_interval: 10
+
+config :logger, level: :info

--- a/lib/ex_double_entry.ex
+++ b/lib/ex_double_entry.ex
@@ -1,4 +1,15 @@
 defmodule ExDoubleEntry do
+  @moduledoc """
+  Contains the main public API, delegating to children modules.
+
+  # Key functions (delegated)
+
+  - `make_account!/2`: Creates a new account with zero balance.
+  - `lookup_account!/2`: Retrieves an existing account.
+  - `lock_accounts/2`: Locks multiple accounts and executes a function atomically (only on PostgreSQL and MySQL).
+  - `transfer!/1`: Performs a validated, atomic transfer (raising on errors).
+  - `transfer/1`: Non-raising variant of `transfer!/1`.
+  """
   @db_table_prefix Application.compile_env(:ex_double_entry, :db_table_prefix, nil)
   @repo Application.compile_env(:ex_double_entry, :repo, ExDoubleEntry.Repo)
 

--- a/lib/ex_double_entry.ex
+++ b/lib/ex_double_entry.ex
@@ -1,6 +1,6 @@
 defmodule ExDoubleEntry do
-  @db_table_prefix Application.fetch_env!(:ex_double_entry, :db_table_prefix)
-  @repo Application.fetch_env!(:ex_double_entry, :repo)
+  @db_table_prefix Application.compile_env(:ex_double_entry, :db_table_prefix, nil)
+  @repo Application.compile_env(:ex_double_entry, :repo, ExDoubleEntry.Repo)
 
   def db_table_prefix, do: @db_table_prefix
 
@@ -26,7 +26,7 @@ defmodule ExDoubleEntry do
   ## Examples
 
   iex> [ExDoubleEntry.make_account!(:savings)] |> ExDoubleEntry.lock_accounts(fn -> true end)
-  {:ok, true}
+  `{:ok, true}`
   """
   defdelegate lock_accounts(accounts, fun), to: ExDoubleEntry.AccountBalance, as: :lock_multi!
 
@@ -34,14 +34,11 @@ defmodule ExDoubleEntry do
   ## Examples
 
   iex> %ExDoubleEntry.Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %ExDoubleEntry.Account{identifier: :checking, currency: :USD, balance: Money.new(42, :USD), positive_only?: false},
-  iex>   to: %ExDoubleEntry.Account{identifier: :savings, currency: :USD, balance: Money.new(0, :USD)},
-  iex>   code: :deposit
-  iex> }
-  iex> |> ExDoubleEntry.transfer!()
-  iex> |> Tuple.to_list()
-  iex> |> List.first()
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %ExDoubleEntry.Account{identifier: :checking, currency: :USD, balance: Money.new(42, :USD), positive_only?: false},
+  ...>   to: %ExDoubleEntry.Account{identifier: :savings, currency: :USD, balance: Money.new(0, :USD)},
+  ...>   code: :deposit
+  ...> } |> ExDoubleEntry.transfer!() |> Tuple.to_list() |> List.first()
   :ok
   """
   defdelegate transfer!(transfer), to: ExDoubleEntry.Transfer, as: :perform!

--- a/lib/ex_double_entry/application.ex
+++ b/lib/ex_double_entry/application.ex
@@ -1,13 +1,13 @@
 defmodule ExDoubleEntry.Application do
+  @moduledoc false
   use Application
 
   @impl true
   def start(_type, _args) do
     children =
-      with {:ok, repos} <- Application.fetch_env(:ex_double_entry, :ecto_repos) do
+      case Application.fetch_env(:ex_double_entry, :ecto_repos) do
         # ecto_repos are only required for development and test
-        repos
-      else
+        {:ok, repos} -> repos
         _ -> []
       end
 

--- a/lib/ex_double_entry/ecto_types/currency.ex
+++ b/lib/ex_double_entry/ecto_types/currency.ex
@@ -1,5 +1,6 @@
 if Code.ensure_loaded?(Ecto.Type) do
   defmodule ExDoubleEntry.EctoType.Currency do
+    @moduledoc false
     if macro_exported?(Ecto.Type, :__using__, 1) do
       use Ecto.Type
     else

--- a/lib/ex_double_entry/ecto_types/identifier.ex
+++ b/lib/ex_double_entry/ecto_types/identifier.ex
@@ -1,5 +1,6 @@
 if Code.ensure_loaded?(Ecto.Type) do
   defmodule ExDoubleEntry.EctoType.Identifier do
+    @moduledoc false
     if macro_exported?(Ecto.Type, :__using__, 1) do
       use Ecto.Type
     else

--- a/lib/ex_double_entry/ecto_types/scope.ex
+++ b/lib/ex_double_entry/ecto_types/scope.ex
@@ -1,5 +1,6 @@
 if Code.ensure_loaded?(Ecto.Type) do
   defmodule ExDoubleEntry.EctoType.Scope do
+    @moduledoc false
     if macro_exported?(Ecto.Type, :__using__, 1) do
       use Ecto.Type
     else

--- a/lib/ex_double_entry/repo.ex
+++ b/lib/ex_double_entry/repo.ex
@@ -1,7 +1,9 @@
 defmodule ExDoubleEntry.Repo do
-  @db Application.fetch_env!(:ex_double_entry, :db)
+  @moduledoc false
+  @db Application.compile_env(:ex_double_entry, :db, :postgres)
 
   @db_adapter (case @db do
+                 :sqlite3 -> Ecto.Adapters.SQLite3
                  :postgres -> Ecto.Adapters.Postgres
                  :mysql -> Ecto.Adapters.MyXQL
                end)

--- a/lib/ex_double_entry/schemas/account_balance.ex
+++ b/lib/ex_double_entry/schemas/account_balance.ex
@@ -1,8 +1,40 @@
 defmodule ExDoubleEntry.AccountBalance do
+  @moduledoc """
+  Defines the Ecto schema and operations for account balances.
+
+  ## Schema fields
+
+  - `:identifier` - Unique identifier for the account.
+  - `:currency` - Currency code for the balance.
+  - `:scope` - Optional scope for the account.
+  - `:balance_amount` - The current balance as an integer (in the smallest unit of the currency).
+  - Timestamps with microsecond precision (`:utc_datetime_usec`).
+
+  ## Key functions
+
+  - `find/1`: Retrieves an `%AccountBalance{}` for a given `%Account{}` without locking.
+  - `create!/1`: Creates a new `%AccountBalance{}` with zero balance for an `%Account{}`.
+  - `for_account!/2`: Retrieves or creates an `%AccountBalance{}` for an `%Account{}`, with optional locking.
+  - `for_account/2`: Retrieves an `%AccountBalance{}` for an `%Account{}`, with optional locking.
+  - `lock!/1`: Locks and retrieves an `%AccountBalance{}` for an `%Account{}` (uses row-level locking for Postgres/MySQL; relies on transaction serialization in WAL mode for SQLite3).
+  - `lock_multi!/2`: Locks multiple accounts in a transaction and executes a function atomically (sorted to avoid deadlocks).
+  - `update_balance!/2`: Updates the balance of a locked `%AccountBalance{}`.
+
+  ## Database considerations
+
+  - Supports Postgres (default), MySQL, and SQLite3 via the `:db` compile-time configuration.
+  - For SQLite3 (`db: :sqlite3`), row-level locking is skipped, relying on WAL mode for serialization; use in environments of low concurrency / write contention only.
+  - Unique constraint on `[:scope, :currency, :identifier]` with adapter-specific naming (prefixed accordingly for SQLite3).
+
+  See `ExDoubleEntry.Transfer` for transfer operations that use these balances.
+  """
+
   use Ecto.Schema
   import Ecto.{Changeset, Query}
 
   alias ExDoubleEntry.{Account, AccountBalance}
+
+  @db Application.compile_env(:ex_double_entry, :db, :postgres)
 
   schema "#{ExDoubleEntry.db_table_prefix()}account_balances" do
     field(:identifier, ExDoubleEntry.EctoType.Identifier)
@@ -17,7 +49,18 @@ defmodule ExDoubleEntry.AccountBalance do
     %AccountBalance{}
     |> cast(params, [:identifier, :currency, :scope, :balance_amount])
     |> validate_required([:identifier, :currency, :balance_amount])
-    |> unique_constraint(:identifier, name: :scope_currency_identifier_index)
+    |> unique_constraint(:identifier, name: constraint_name())
+  end
+
+  @dialyzer {:nowarn_function, constraint_name: 0}
+  defp constraint_name do
+    base_name = "scope_currency_identifier_index"
+
+    case @db do
+      :sqlite3 -> "#{ExDoubleEntry.db_table_prefix()}account_balances_#{base_name}"
+      db when db in [:postgres, :mysql] -> base_name
+    end
+    |> String.to_atom()
   end
 
   def find(%Account{} = account) do
@@ -72,8 +115,8 @@ defmodule ExDoubleEntry.AccountBalance do
 
   defp lock_cond(query, lock) do
     case lock do
-      true -> lock(query, "FOR SHARE NOWAIT")
-      false -> query
+      true when @db != :sqlite3 -> lock(query, "FOR SHARE NOWAIT")
+      _ -> query
     end
   end
 
@@ -83,7 +126,7 @@ defmodule ExDoubleEntry.AccountBalance do
 
   def lock_multi!(accounts, fun) do
     ExDoubleEntry.repo().transaction(fn ->
-      accounts |> Enum.sort() |> Enum.map(fn account -> lock!(account) end)
+      accounts |> Enum.sort() |> Enum.each(fn account -> lock!(account) end)
       fun.()
     end)
   end

--- a/lib/ex_double_entry/schemas/line.ex
+++ b/lib/ex_double_entry/schemas/line.ex
@@ -1,4 +1,40 @@
 defmodule ExDoubleEntry.Line do
+  @moduledoc """
+  Defines the Ecto schema and operations for transaction lines.
+
+  ## Schema fields
+
+  - `:account_identifier` - Identifier of the account for this line.
+  - `:account_scope` - Optional scope for the account.
+  - `:currency` - Currency code for the transaction.
+  - `:amount` - Transaction amount as an integer (in the smallest unit of the currency).
+  - `:balance_amount` - Updated balance after this transaction.
+  - `:code` - Transaction code.
+  - `:partner_identifier` - Identifier of the partner account.
+  - `:partner_scope` - Optional scope for the partner account.
+  - `:metadata` - Arbitrary map for additional transaction data.
+  - `:partner_line_id` - Foreign key to the paired (partner) line.
+  - `:account_balance_id` - Foreign key to the associated account balance.
+  - Timestamps with microsecond precision (`:utc_datetime_usec`).
+
+  ## Associations
+
+  - `belongs_to :partner_line` - The paired debit/credit line.
+  - `belongs_to :account_balance` - The affected account balance.
+
+  ## Key functions
+
+  - `insert!/1`: Inserts a new transaction line for a transfer, computing the updated balance.
+  - `update_partner_line_id!/2`: Updates the partner line ID for pairing debits and credits.
+
+  ## Database considerations
+
+  - Table name prefixed via `ExDoubleEntry.db_table_prefix()`.
+  - Validates required fields and foreign keys.
+  - Used internally by transfer operations to record atomic debits/credits.
+
+  See `ExDoubleEntry.Transfer` for high-level transfer APIs and `ExDoubleEntry.AccountBalance` for balance management.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/ex_double_entry/services/account.ex
+++ b/lib/ex_double_entry/services/account.ex
@@ -1,4 +1,34 @@
 defmodule ExDoubleEntry.Account do
+  @moduledoc """
+  Defines the struct and operations for accounts.
+
+  ## Struct fields
+
+  - `:id` - Optional internal ID (from the database).
+  - `:identifier` - Required unique identifier for the account (atom or string).
+  - `:scope` - Optional scope to differentiate accounts (e.g., user-specific).
+  - `:currency` - Required currency code (e.g., `:USD`).
+  - `:balance` - Optional current balance as a `%Money{}` struct.
+  - `:positive_only?` - Flag indicating if the account balance must remain non-negative.
+
+  ## Key functions
+
+  - `present/1`: Converts an `%AccountBalance{}` schema or `nil` to an `%Account{}` struct.
+  - `lookup!/2`: Retrieves an existing `%Account{}` by identifier and options (e.g., currency, scope). Raises `ExDoubleEntry.Account.NotFoundError` if not found.
+  - `make!/2`: Creates a new `%Account{}` with zero balance, enforcing required fields and configuration.
+
+  ## Configuration dependencies
+
+  - Uses `:default_currency` from `:ex_double_entry` application config.
+  - Checks `:accounts` config for `:positive_only` flag per identifier.
+
+  ## Exceptions
+
+  - `ExDoubleEntry.Account.NotFoundError`: Raised when an account is not found.
+  - `ExDoubleEntry.Account.InvalidScopeError`: Raised for invalid scopes (e.g., empty string).
+
+  See `ExDoubleEntry.AccountBalance` for balance-related operations and `ExDoubleEntry.Transfer` for transfers between accounts.
+  """
   @enforce_keys [:identifier, :currency]
   defstruct [:id, :identifier, :scope, :currency, :balance, :positive_only?]
 
@@ -52,9 +82,15 @@ defmodule ExDoubleEntry.Account do
 end
 
 defmodule ExDoubleEntry.Account.NotFoundError do
+  @moduledoc """
+  Raised when an account is not found.
+  """
   defexception message: "Account not found."
 end
 
 defmodule ExDoubleEntry.Account.InvalidScopeError do
+  @moduledoc """
+  Raised for invalid scopes (empty string).
+  """
   defexception message: "Invalid scope: empty string not allowed."
 end

--- a/lib/ex_double_entry/services/guard.ex
+++ b/lib/ex_double_entry/services/guard.ex
@@ -1,16 +1,33 @@
 defmodule ExDoubleEntry.Guard do
+  @moduledoc """
+  Provides guard functions for validating `ExDoubleEntry.Transfer` structs before performing double-entry accounting operations.
+
+  These guards ensure transfers meet criteria such as positive amounts, valid configurations, matching currencies, and sufficient balances for positive-only accounts. Each function returns `{:ok, transfer}` on success or `{:error, reason, message}` on failure.
+
+  ## Key functions
+
+  - `positive_amount?/1`: Ensures the transfer amount is positive.
+  - `valid_definition?/1`: Verifies the transfer code and account pair are defined in the application configuration (:transfers).
+  - `matching_currency?/1`: Checks that the currencies of the money, from-account, and to-account match.
+  - `positive_balance_if_enforced?/1`: Ensures the from-account has sufficient balance if it is marked as positive-only (configured via `:accounts`).
+
+  ## Configuration dependencies
+
+  - Relies on `:transfers` config for valid codes and pairs.
+  - Uses `:accounts` config for `:positive_only` flags.
+
+  See `ExDoubleEntry.Transfer` for high-level transfer APIs.
+  """
   alias ExDoubleEntry.Transfer
 
   @doc """
   ## Examples
 
-  iex> %Transfer{money: Money.new(42, :USD), from: nil, to: nil, code: nil}
-  iex> |> Guard.positive_amount?()
-  {:ok, %Transfer{money: Money.new(42, :USD), from: nil, to: nil, code: nil}}
+  iex> %Transfer{money: Money.new(42, :USD), from: nil, to: nil, code: nil} |> Guard.positive_amount?()
+  `{:ok, %Transfer{money: Money.new(42, :USD), from: nil, to: nil, code: nil}}`
 
-  iex> %Transfer{money: Money.new(-42, :USD), from: nil, to: nil, code: nil}
-  iex> |> Guard.positive_amount?()
-  {:error, :positive_amount_only, ""}
+  iex> %Transfer{money: Money.new(-42, :USD), from: nil, to: nil, code: nil} |> Guard.positive_amount?()
+  `{:error, :positive_amount_only, ""}`
   """
   def positive_amount?(%Transfer{money: money} = transfer) do
     case Money.positive?(money) do
@@ -23,12 +40,11 @@ defmodule ExDoubleEntry.Guard do
   ## Examples
 
   iex> %Transfer{
-  iex>   money: nil,
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.valid_definition?()
+  ...>   money: nil,
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.valid_definition?()
   {
     :ok,
     %Transfer{
@@ -40,22 +56,20 @@ defmodule ExDoubleEntry.Guard do
   }
 
   iex> %Transfer{
-  iex>   money: nil,
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :give_away
-  iex> }
-  iex> |> Guard.valid_definition?()
-  {:error, :undefined_transfer_code, "Transfer code :give_away is undefined."}
+  ...>   money: nil,
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :give_away
+  ...> } |> Guard.valid_definition?()
+  `{:error, :undefined_transfer_code, "Transfer code :give_away is undefined."}`
 
   iex> %Transfer{
-  iex>   money: nil,
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :withdraw
-  iex> }
-  iex> |> Guard.valid_definition?()
-  {:error, :undefined_transfer_pair, "Transfer pair :checking -> :savings does not exist for code withdraw."}
+  ...>   money: nil,
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :withdraw
+  ...> } |> Guard.valid_definition?()
+  `{:error, :undefined_transfer_pair, "Transfer pair :checking -> :savings does not exist for code :withdraw."}`
   """
   def valid_definition?(%Transfer{from: from, to: to, code: code} = transfer) do
     with {:ok, pairs} <-
@@ -66,11 +80,11 @@ defmodule ExDoubleEntry.Guard do
       {:ok, transfer}
     else
       :error ->
-        {:error, :undefined_transfer_code, "Transfer code :#{code} is undefined."}
+        {:error, :undefined_transfer_code, "Transfer code #{inspect(code)} is undefined."}
 
       false ->
         {:error, :undefined_transfer_pair,
-         "Transfer pair :#{from.identifier} -> :#{to.identifier} does not exist for code #{code}."}
+         "Transfer pair #{inspect(from.identifier)} -> #{inspect(to.identifier)} does not exist for code #{inspect(code)}."}
     end
   end
 
@@ -78,12 +92,11 @@ defmodule ExDoubleEntry.Guard do
   ## Examples
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.matching_currency?()
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.matching_currency?()
   {
     :ok,
     %Transfer{
@@ -95,29 +108,27 @@ defmodule ExDoubleEntry.Guard do
   }
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :AUD),
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.matching_currency?()
-  {:error, :mismatched_currencies, "Attempted to transfer :AUD from :checking in :USD to :savings in :USD."}
+  ...>   money: Money.new(42, :AUD),
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.matching_currency?()
+  `{:error, :mismatched_currencies, "Attempted to transfer :AUD from :checking in :USD to :savings in :USD."}`
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD},
-  iex>   to: %Account{identifier: :savings, currency: :AUD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.matching_currency?()
-  {:error, :mismatched_currencies, "Attempted to transfer :USD from :checking in :USD to :savings in :AUD."}
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD},
+  ...>   to: %Account{identifier: :savings, currency: :AUD},
+  ...>   code: :deposit
+  ...> } |> Guard.matching_currency?()
+  `{:error, :mismatched_currencies, "Attempted to transfer :USD from :checking in :USD to :savings in :AUD."}`
   """
   def matching_currency?(%Transfer{money: money, from: from, to: to} = transfer) do
     if from.currency == money.currency and to.currency == money.currency do
       {:ok, transfer}
     else
       {:error, :mismatched_currencies,
-       "Attempted to transfer :#{money.currency} from :#{from.identifier} in :#{from.currency} to :#{to.identifier} in :#{to.currency}."}
+       "Attempted to transfer #{inspect(money.currency)} from #{inspect(from.identifier)} in #{inspect(from.currency)} to #{inspect(to.identifier)} in #{inspect(to.currency)}."}
     end
   end
 
@@ -125,12 +136,11 @@ defmodule ExDoubleEntry.Guard do
   ## Examples
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(42, :USD), positive_only?: true},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.positive_balance_if_enforced?()
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(42, :USD), positive_only?: true},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.positive_balance_if_enforced?()
   {
     :ok,
     %Transfer{
@@ -142,12 +152,11 @@ defmodule ExDoubleEntry.Guard do
   }
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD), positive_only?: false},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.positive_balance_if_enforced?()
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD), positive_only?: false},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.positive_balance_if_enforced?()
   {
     :ok,
     %Transfer{
@@ -159,12 +168,11 @@ defmodule ExDoubleEntry.Guard do
   }
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD)},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.positive_balance_if_enforced?()
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD)},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.positive_balance_if_enforced?()
   {
     :ok,
     %Transfer{
@@ -176,18 +184,17 @@ defmodule ExDoubleEntry.Guard do
   }
 
   iex> %Transfer{
-  iex>   money: Money.new(42, :USD),
-  iex>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD), positive_only?: true},
-  iex>   to: %Account{identifier: :savings, currency: :USD},
-  iex>   code: :deposit
-  iex> }
-  iex> |> Guard.positive_balance_if_enforced?()
-  {:error, :insufficient_balance, "Transfer amount: 42, :checking balance amount: 10"}
+  ...>   money: Money.new(42, :USD),
+  ...>   from: %Account{identifier: :checking, currency: :USD, balance: Money.new(10, :USD), positive_only?: true},
+  ...>   to: %Account{identifier: :savings, currency: :USD},
+  ...>   code: :deposit
+  ...> } |> Guard.positive_balance_if_enforced?()
+  `{:error, :insufficient_balance, "Transfer amount: 42, :checking balance amount: 10"}`
   """
   def positive_balance_if_enforced?(%Transfer{money: money, from: from} = transfer) do
     if !!from.positive_only? and Money.cmp(from.balance, money) == :lt do
       {:error, :insufficient_balance,
-       "Transfer amount: #{money.amount}, :#{from.identifier} balance amount: #{from.balance.amount}"}
+       "Transfer amount: #{money.amount}, #{inspect(from.identifier)} balance amount: #{from.balance.amount}"}
     else
       {:ok, transfer}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule ExDoubleEntry.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(:test_mysql), do: ["lib", "test/support"]
+  defp elixirc_paths(:test_sqlite3), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
@@ -33,10 +34,13 @@ defmodule ExDoubleEntry.MixProject do
       {:jason, "~> 1.2"},
       {:money, "~> 1.9"},
       {:ecto_sql, "~> 3.7"},
+      {:ecto_sqlite3, ">= 0.0.0", optional: true},
+      {:exqlite, ">= 0.0.0", optional: true},
       {:postgrex, ">= 0.0.0", optional: true},
       {:myxql, ">= 0.0.0", optional: true},
-      {:ex_machina, "~> 2.7", only: [:test, :test_mysql]},
-      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+      {:ex_machina, "~> 2.7", only: [:test, :test_mysql, :test_sqlite3]},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:credo, "~> 1.7", only: :dev}
     ]
   end
 

--- a/priv/repo/migrations/001_ex_double_entry_tables.exs
+++ b/priv/repo/migrations/001_ex_double_entry_tables.exs
@@ -3,40 +3,61 @@ defmodule ExDoubleEntry.Repo.Migrations.ExDoubleEntryMoney do
 
   def change do
     json_type =
-      if ExDoubleEntry.Repo.__adapter__ == Ecto.Adapters.Postgres do
-        :jsonb
-      else
-        :json
-      end
+      if Application.get_env(:ex_double_entry, :db) == :postgres,
+        do: :jsonb,
+        else: :json
 
-    create table(:"#{ExDoubleEntry.db_table_prefix}account_balances") do
-      add :identifier, :string, null: false
-      add :currency, :string, null: false
-      add :scope, :string, null: false, default: ""
-      add :balance_amount, :bigint, null: false
+    create table(:"#{ExDoubleEntry.db_table_prefix()}account_balances") do
+      add(:identifier, :string, null: false)
+      add(:currency, :string, null: false)
+      add(:scope, :string, null: false, default: "")
+      add(:balance_amount, :bigint, null: false)
 
       timestamps(type: :utc_datetime_usec)
     end
 
-    create index(:"#{ExDoubleEntry.db_table_prefix}account_balances", [:scope, :currency, :identifier], unique: true, name: :scope_currency_identifier_index)
+    create(
+      index(
+        :"#{ExDoubleEntry.db_table_prefix()}account_balances",
+        [:scope, :currency, :identifier],
+        unique: true,
+        name: :scope_currency_identifier_index
+      )
+    )
 
-    create table(:"#{ExDoubleEntry.db_table_prefix}lines") do
-      add :account_identifier, :string, null: false
-      add :account_scope, :string, null: false, default: ""
-      add :currency, :string, null: false
-      add :amount, :bigint, null: false
-      add :balance_amount, :bigint, null: false
-      add :code, :string, null: false
-      add :partner_identifier, :string, null: false
-      add :partner_scope, :string, null: false, default: ""
-      add :metadata, json_type
-      add :partner_line_id, references(:"#{ExDoubleEntry.db_table_prefix}lines")
-      add :account_balance_id, references(:"#{ExDoubleEntry.db_table_prefix}account_balances"), null: false
+    create table(:"#{ExDoubleEntry.db_table_prefix()}lines") do
+      add(:account_identifier, :string, null: false)
+      add(:account_scope, :string, null: false, default: "")
+      add(:currency, :string, null: false)
+      add(:amount, :bigint, null: false)
+      add(:balance_amount, :bigint, null: false)
+      add(:code, :string, null: false)
+      add(:partner_identifier, :string, null: false)
+      add(:partner_scope, :string, null: false, default: "")
+      add(:metadata, json_type)
+      add(:partner_line_id, references(:"#{ExDoubleEntry.db_table_prefix()}lines"))
+
+      add(:account_balance_id, references(:"#{ExDoubleEntry.db_table_prefix()}account_balances"),
+        null: false
+      )
 
       timestamps(type: :utc_datetime_usec)
     end
 
-    create index(:"#{ExDoubleEntry.db_table_prefix}lines", [:code, :account_identifier, :currency, :inserted_at], name: :code_account_identifier_currency_inserted_at_index)
-    create index(:"#{ExDoubleEntry.db_table_prefix}lines", [:account_scope, :account_identifier, :currency, :inserted_at], name: :account_scope_account_identifier_currency_inserted_at_index)
+    create(
+      index(
+        :"#{ExDoubleEntry.db_table_prefix()}lines",
+        [:code, :account_identifier, :currency, :inserted_at],
+        name: :code_account_identifier_currency_inserted_at_index
+      )
+    )
+
+    create(
+      index(
+        :"#{ExDoubleEntry.db_table_prefix()}lines",
+        [:account_scope, :account_identifier, :currency, :inserted_at],
+        name: :account_scope_account_identifier_currency_inserted_at_index
+      )
+    )
   end
 end

--- a/test/ex_double_entry/schemas/account_balance_test.exs
+++ b/test/ex_double_entry/schemas/account_balance_test.exs
@@ -116,6 +116,7 @@ defmodule ExDoubleEntry.AccountBalanceTest do
       [acc_a: acc_a, acc_b: acc_b]
     end
 
+    @tag :requires_locking
     test "multiple locks", %{acc_a: acc_a, acc_b: acc_b} do
       tasks =
         for i <- 0..4 do
@@ -128,6 +129,7 @@ defmodule ExDoubleEntry.AccountBalanceTest do
       assert Enum.reduce(tasks, 0, fn {:ok, n}, acc -> acc + n end) == 10
     end
 
+    @tag :requires_locking
     test "failed locks", %{acc_a: acc_a, acc_b: acc_b} do
       [
         Task.async(fn ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,4 +1,5 @@
 defmodule ExDoubleEntry.DataCase do
+  @moduledoc false
   use ExUnit.CaseTemplate
 
   using do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,4 +1,5 @@
 defmodule ExDoubleEntry.Factory do
+  @moduledoc false
   use ExMachina.Ecto, repo: ExDoubleEntry.repo()
 
   def account_balance_factory do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,10 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 ExUnit.start(timeout: 300_000)
+
+if Application.get_env(:ex_double_entry, :db) == :sqlite3 do
+  ExUnit.configure(exclude: [:requires_locking])
+end
+
 Ecto.Adapters.SQL.Sandbox.mode(ExDoubleEntry.repo(), :manual)
 
 require Logger


### PR DESCRIPTION
- Works with SQLite3 (without row-level locking)
- Conditionally disable locking in `AccountBalance.lock_cond/2` when database is SQLite3
- Test configuration for SQLite3
- Tagged 2 locking-dependent tests that are disabled when database is SQLite3
- Cleaned up multi-line doctests
- Added documentation to key modules
- Updated `README.md` for SQLite3 and locking
- Misc. improvements according to Credo issues